### PR TITLE
Add MUSY_VERSION 2.0.3 (Super Mario Strikers) support

### DIFF
--- a/src/musyx/runtime/hw_dolphin.c
+++ b/src/musyx/runtime/hw_dolphin.c
@@ -14,6 +14,19 @@
 static DSPTaskInfo dsp_task ATTRIBUTE_ALIGN(8);
 static u16 dram_image[4096] ATTRIBUTE_ALIGN(32);
 
+#if MUSY_VERSION >= MUSY_VERSION_CHECK(2, 0, 3)
+static SND_SOME_CALLBACK userCallback;
+u8 salAIBufferIndex;
+static void* salAIBufferBase;
+static volatile u32 salDspIsDone;
+static volatile u32 salLogicIsWaiting;
+static volatile u32 salLogicActive;
+static volatile OSTick salLastTick;
+static volatile u32 salDspInitIsDone;
+static OSThreadQueue salWaitForDSPThreadQueue;
+static volatile u16 hwIrqLevel;
+static volatile u32 oldState;
+#else
 static volatile u32 oldState = 0;
 static volatile u16 hwIrqLevel = 0;
 static volatile u32 salDspInitIsDone = 0;
@@ -24,6 +37,7 @@ static volatile u32 salDspIsDone = 0;
 static void* salAIBufferBase = NULL;
 u8 salAIBufferIndex = 0;
 static SND_SOME_CALLBACK userCallback = NULL;
+#endif
 
 #define DMA_BUFFER_LEN 0x280
 
@@ -207,6 +221,8 @@ void hwIRQEnterCritical() { OSDisableInterrupts(); }
 
 void hwIRQLeaveCritical() { OSEnableInterrupts(); }
 
+#if MUSY_VERSION != MUSY_VERSION_CHECK(2, 0, 3) //
 u32 aramSize = 0;
 u8* aramBase = NULL;
+#endif
 #endif

--- a/src/musyx/runtime/hw_dspctrl.c
+++ b/src/musyx/runtime/hw_dspctrl.c
@@ -37,7 +37,11 @@ static u32 dbgActiveVoicesMax = 0;
 #endif
 
 #if MUSY_VERSION >= MUSY_VERSION_CHECK(2, 0, 1)
+#if MUSY_VERSION >= MUSY_VERSION_CHECK(2, 0, 3)
+u16 compressorTable[3360] ATTRIBUTE_ALIGN(32) = {
+#else
 u16 compressorTable[3360] = {
+#endif
     0x7FA1, 0x7F43, 0x7EE6, 0x7E88, 0x7E2B, 0x7DCE, 0x7D72, 0x7D16, 0x7CBA, 0x7C5E, 0x7C02, 0x7BA7,
     0x7B4C, 0x7AF1, 0x7A97, 0x7A3D, 0x79E3, 0x7989, 0x7930, 0x78D6, 0x787E, 0x7825, 0x77CD, 0x7774,
     0x771C, 0x76C5, 0x766D, 0x7616, 0x75BF, 0x7569, 0x7512, 0x74BC, 0x7466, 0x7411, 0x73BB, 0x7366,
@@ -549,13 +553,17 @@ static const u16 dspMixerCycles[32] = {
 static const u16 dspMixerCyclesMain[16] = {
     0, 760, 760, 1470, 760, 1520, 1520, 2230, 0, 1265, 1265, 2470, 1265, 2530, 2530, 3735,
 };
+#if MUSY_VERSION <= MUSY_VERSION_CHECK(2, 0, 2) // dropped in the SMS 2.0.3 fork (unused; kept for upstream <= 2.0.2)
 static const u16 dspMixerCyclesAux[32] = {
     0, 760, 760, 1470, 0, 1265, 1265, 2470, 760,  1520, 1520, 2230, 760,  2025, 2025, 3230,
     0, 760, 760, 1470, 0, 1265, 1265, 2470, 1265, 2025, 2025, 2735, 1265, 2530, 2530, 3735,
 };
 #endif
+#endif
 
+#if MUSY_VERSION <= MUSY_VERSION_CHECK(2, 0, 2) // dropped in the SMS 2.0.3 fork (unused; kept for upstream <= 2.0.2)
 void salDeactivateStudio(u8 studio) { dspStudio[studio].state = 0; }
+#endif
 
 static u32 salCheckVolErrorAndResetDelta(u16* dsp_vol, u16* dsp_delta, u16* last_vol, u16 targetVol,
                                          u16* resetFlags, u16 resetMask) {
@@ -623,7 +631,11 @@ static void sal_update_hostplayinfo(DSPvoice* dsp_vptr) {
   }
 }
 
+#if MUSY_VERSION >= MUSY_VERSION_CHECK(2, 0, 3)
+static inline void AddDpop(s32* sum, s16 delta) {
+#else
 static void AddDpop(s32* sum, s16 delta) {
+#endif
   *sum += (int)delta;
   *sum = (*sum > 0x7fffff) ? 0x7fffff : (*sum < -0x7fffff ? -0x7fffff : *sum);
 }
@@ -2052,6 +2064,7 @@ void salDeactivateVoice(DSPvoice* dsp_vptr) {
   dsp_vptr->state = 0;
 }
 
+#if MUSY_VERSION <= MUSY_VERSION_CHECK(2, 0, 2) // dropped in the SMS 2.0.3 fork (unused; kept for upstream <= 2.0.2)
 void salReconnectVoice(DSPvoice* dsp_vptr, u8 studio) {
   if (dsp_vptr->state != 0) {
     if (dsp_vptr->prev != NULL) {
@@ -2108,6 +2121,7 @@ bool salRemoveStudioInput(DSPstudioinfo* stp, SND_STUDIO_INPUT* desc) {
 
   return 0;
 }
+#endif
 
 void salHandleAuxProcessing() {
   DSPstudioinfo* r28;

--- a/src/musyx/runtime/s_data.c
+++ b/src/musyx/runtime/s_data.c
@@ -22,10 +22,15 @@ static GSTACK_INST gsDefault;
 #endif
 
 #if MUSY_VERSION >= MUSY_VERSION_CHECK(2, 0, 1)
+#if MUSY_VERSION == MUSY_VERSION_CHECK(2, 0, 3)
+static GSTACK_INST* gsRoot;
+static GSTACK_INST* gsCurrent;
+static unsigned long gsNextID;
+#else
 static unsigned long gsNextID;
 static GSTACK_INST* gsCurrent;
 static GSTACK_INST* gsRoot;
-
+#endif
 static void dataInitStackInstance(GSTACK_INST* inst, unsigned long id, unsigned long aramBase,
                                   unsigned long aramSize) {
   inst->id = id;
@@ -498,6 +503,82 @@ u32 seqPlaySong(u16 sgid, u16 sid, void* arrfile, SND_PLAYPARA* para, u8 irq_cal
   return 0xffffffff;
 }
 
+#if MUSY_VERSION == MUSY_VERSION_CHECK(2, 0, 3)
+inline u32 _seqPlaySong(u16 sgid, u16 sid, void* arrfile, SND_PLAYPARA* para, u8 irq_call, u8 studio) {
+  int i;
+  GROUP_DATA* g;
+  PAGE* norm;
+  PAGE* drum;
+  MIDISETUP* midiSetup;
+  u32 seqId;
+  void* prj;
+#if MUSY_VERSION >= MUSY_VERSION_CHECK(2, 0, 1)
+  GSTACK_INST* gsi;
+#endif
+  MUSY_ASSERT_MSG(sndActive != FALSE, "Sound system is not initialized.");
+
+#if MUSY_VERSION >= MUSY_VERSION_CHECK(2, 0, 1)
+  for (gsi = gsRoot; gsi != NULL; gsi = gsi->next) {
+#endif
+    for (i = 0; i < SP_GSI; ++i) {
+      if (GS_GSI[i].gAddr->id != sgid) {
+        continue;
+      }
+
+      if (GS_GSI[i].gAddr->type == 0) {
+        g = GS_GSI[i].gAddr;
+        prj = GS_GSI[i].prjAddr;
+        norm = (PAGE*)((size_t)prj + g->data.song.normpageOff);
+        drum = (PAGE*)((size_t)prj + g->data.song.drumpageOff);
+        midiSetup = (MIDISETUP*)((size_t)prj + g->data.song.midiSetupOff);
+        while (midiSetup->songId != 0xFFFF) {
+          if (midiSetup->songId == sid) {
+            if (irq_call != 0) {
+              seqId = seqStartPlay(norm, drum, midiSetup, arrfile, para, studio, sgid);
+            } else {
+              hwDisableIrq();
+              seqId = seqStartPlay(norm, drum, midiSetup, arrfile, para, studio, sgid);
+              hwEnableIrq();
+            }
+            return seqId;
+          }
+
+          ++midiSetup;
+        }
+
+#if MUSY_VERSION <= MUSY_VERSION_CHECK(2, 0, 1)
+        MUSY_DEBUG("Song ID=%d is not in group ID=%d.", sid, sgid);
+#else
+      MUSY_DEBUG("Song ID=%d is not in group ID=%d.\n", sid, sgid);
+#endif
+        return 0xffffffff;
+      } else {
+#if MUSY_VERSION <= MUSY_VERSION_CHECK(2, 0, 1)
+        MUSY_DEBUG("Group ID=%d is no songgroup.", sgid);
+#else
+      MUSY_DEBUG("Group ID=%d is no songgroup.\n", sgid);
+#endif
+        return 0xffffffff;
+      }
+    }
+#if MUSY_VERSION >= MUSY_VERSION_CHECK(2, 0, 1)
+  }
+#endif
+
+#if MUSY_VERSION <= MUSY_VERSION_CHECK(2, 0, 0)
+  MUSY_DEBUG("Group ID=%d is not on soundstack.", sgid);
+#else
+  MUSY_DEBUG("Group ID=%d is not on any soundstack.\n", sgid);
+#endif
+  return 0xffffffff;
+}
+#endif
+
+
 u32 sndSeqPlayEx(u16 sgid, u16 sid, void* arrfile, SND_PLAYPARA* para, u8 studio) {
+#if MUSY_VERSION == MUSY_VERSION_CHECK(2, 0, 3)
+  return _seqPlaySong(sgid, sid, arrfile, para, 0, studio);
+#else
   return seqPlaySong(sgid, sid, arrfile, para, 0, studio);
+#endif
 }

--- a/src/musyx/runtime/stream.c
+++ b/src/musyx/runtime/stream.c
@@ -14,11 +14,17 @@
 
 static STREAM_INFO streamInfo[64];
 static u32 nextPublicID = 0;
+#if MUSY_VERSION >= MUSY_VERSION_CHECK(2, 0, 3)
+static u8 streamCallCnt;
+static u8 streamCallDelay;
+#endif
 #if MUSY_VERSION >= MUSY_VERSION_CHECK(2, 0, 2)
 static struct streamDefaults streamDefaults;
 #endif
+#if MUSY_VERSION <= MUSY_VERSION_CHECK(2, 0, 2)
 static u8 streamCallDelay = 0;
 static u8 streamCallCnt = 0;
+#endif
 
 void streamInit() {
   s32 i;
@@ -294,6 +300,26 @@ void streamKill(u32 voice) {
   default:
     break;
   }
+#elif MUSY_VERSION == MUSY_VERSION_CHECK(2, 0, 3)
+  u32 i;
+  u8 state;
+  u32 streamVoice;
+
+  for (i = 0; i < 64; ++i) {
+    si = &streamInfo[i];
+    state = si->state;
+    if (state == 1 || state == 2) {
+      streamVoice = si->voice;
+      if (streamVoice == voice) {
+        if (state == 2) {
+          voiceUnblock(streamVoice); // TODO fix in release
+        }
+        si->state = 3;
+        si->updateFunction(0, 0, 0, 0, si->user);
+        break;
+      }
+    }
+  }
 #else
   u32 i;
 
@@ -322,7 +348,11 @@ static u32 GetPrivateIndex(u32 publicID) {
   return -1;
 }
 
+#if MUSY_VERSION >= MUSY_VERSION_CHECK(2, 0, 3)
+static inline u32 GeneratePublicID() {
+#else
 static u32 GeneratePublicID() {
+#endif
   u32 id; // r30
   u32 i;  // r31
 
@@ -341,14 +371,16 @@ static u32 GeneratePublicID() {
   return id;
 }
 
+#if MUSY_VERSION <= MUSY_VERSION_CHECK(2, 0, 2)
 u32 sndStreamCallbackFrq(u32 msTime) {
   s32 time; // r31
   time = ((msTime * 2 + 5) / 10) - 1;
   streamCallDelay = time < 0 ? 0 : time;
   return (streamCallDelay + 1) * 5;
 }
+#endif
 
-#if MUSY_VERSION >= MUSY_VERSION_CHECK(2, 0, 2)
+#if MUSY_VERSION == MUSY_VERSION_CHECK(2, 0, 2)
 u32 sndStreamGetARAMAddress(u32 stid, u32* aramAddr) {
   u32 i;
   u32 ret = 0;
@@ -596,6 +628,7 @@ SND_STREAMID sndStreamAllocEx(u8 prio, void* buffer, u32 samples, u32 frq, u8 vo
   return stid;
 }
 
+#if MUSY_VERSION <= MUSY_VERSION_CHECK(2, 0, 2)
 u32 sndStreamAllocStereo(u8 prio, void* lBuffer, void* rBuffer, u32 samples, u32 frq, u8 vol,
                          u8 pan, u8 span, u8 auxa, u8 auxb, u8 studio, u32 flags,
                          SND_STREAM_UPDATE_CALLBACK updateFunction, u32 lUser, u32 rUser,
@@ -627,6 +660,7 @@ u32 sndStreamAllocStereo(u8 prio, void* lBuffer, void* rBuffer, u32 samples, u32
   hwEnableIrq();
   return stid[0];
 }
+#endif
 
 u32 sndStreamAllocLength(u32 num, u32 flags) {
   if (flags & 1) {
@@ -657,6 +691,7 @@ void sndStreamADPCMParameter(u32 stid, SND_ADPCMSTREAM_INFO* adpcmInfo) {
   hwEnableIrq();
 }
 
+#if MUSY_VERSION <= MUSY_VERSION_CHECK(2, 0, 2)
 void sndStreamMixParameter(u32 stid, u8 vol, u8 pan, u8 span, u8 fxvol) {
   u32 i; // r31
   MUSY_ASSERT_MSG(sndActive, "Sound system is not initialized.");
@@ -688,6 +723,7 @@ void sndStreamMixParameter(u32 stid, u8 vol, u8 pan, u8 span, u8 fxvol) {
   }
   hwEnableIrq();
 }
+#endif
 
 void sndStreamMixParameterEx(u32 stid, u8 vol, u8 pan, u8 span, u8 auxa, u8 auxb) {
   u32 i; // r31
@@ -723,7 +759,7 @@ void sndStreamMixParameterEx(u32 stid, u8 vol, u8 pan, u8 span, u8 auxa, u8 auxb
   hwEnableIrq();
 }
 
-#if MUSY_VERSION >= MUSY_VERSION_CHECK(2, 0, 2)
+#if MUSY_VERSION == MUSY_VERSION_CHECK(2, 0, 2)
 void sndStreamMixParameterVolume(u32 stid, u8 vol, u8 auxa, u8 auxb) {
   unsigned long i; // r31
   MUSY_ASSERT_MSG(sndActive, "Sound system is not initialized.");
@@ -800,6 +836,7 @@ void sndStreamLPFParameter(u32 stid, u32 enable, u32 frq) {
   hwEnableIrq();
 }
 
+#if MUSY_VERSION != MUSY_VERSION_CHECK(2, 0, 3)
 void sndStreamLPFDefaultParameter(u32 enable, u32 frq) {
   MUSY_ASSERT_MSG(sndActive, "Sound system is not initialized.");
   hwDisableIrq();
@@ -807,6 +844,7 @@ void sndStreamLPFDefaultParameter(u32 enable, u32 frq) {
   streamDefaults.lpfFrq = frq;
   hwEnableIrq();
 }
+#endif
 #endif
 
 void sndStreamFree(SND_STREAMID stid) {

--- a/src/musyx/runtime/synth_vsamples.c
+++ b/src/musyx/runtime/synth_vsamples.c
@@ -67,12 +67,16 @@ u32 vsSampleStartNotify(
     u8 voice
 #endif
 ) {
-  u8 sb; // r29
-  u8 i;  // r28
-#if MUSY_VERSION >= MUSY_VERSION_CHECK(2, 0, 2)
+  u8 sb;
+#if MUSY_VERSION >= MUSY_VERSION_CHECK(2, 0, 3)
+  u8 voice = voiceID & 0xFF;
+  u8 hwVoice;
+#endif
+  u8 i;
+#if MUSY_VERSION == MUSY_VERSION_CHECK(2, 0, 2)
   u8 voice = voiceID;
 #endif
-  size_t addr; // r27
+  size_t addr;
 
   for (i = 0; i < vs.numBuffers; ++i) {
     if (vs.streamBuffer[i].state != 0 && vs.streamBuffer[i].voice == voice) {
@@ -80,11 +84,23 @@ u32 vsSampleStartNotify(
     }
   }
 
+#if MUSY_VERSION >= MUSY_VERSION_CHECK(2, 0, 3)
+  sb = vsAllocateBuffer();
+  hwVoice = voice;
+  vs.voices[hwVoice] = sb;
+#else
   sb = vs.voices[voice] = vsAllocateBuffer();
+#endif
   if (sb != 0xFF) {
+#if MUSY_VERSION >= MUSY_VERSION_CHECK(2, 0, 3)
+    addr = aramGetStreamBufferAddress(vs.voices[hwVoice], 0);
+    hwSetVirtualSampleLoopBuffer(hwVoice, (void*)addr, vs.bufferLength);
+    vs.streamBuffer[sb].info.smpID = hwGetSampleID(hwVoice);
+#else
     addr = aramGetStreamBufferAddress(vs.voices[voice], 0);
     hwSetVirtualSampleLoopBuffer(voice, (void*)addr, vs.bufferLength);
     vs.streamBuffer[sb].info.smpID = hwGetSampleID(voice);
+#endif
     vs.streamBuffer[sb].info.instID = vsNewInstanceID();
 #if MUSY_VERSION >= MUSY_VERSION_CHECK(2, 0, 2)
     if ((vs.streamBuffer[sb].info.vid = vidGetPublicId(voiceID)) != -1) {
@@ -92,9 +108,17 @@ u32 vsSampleStartNotify(
     } else {
       vs.streamBuffer[sb].info.seqID = -1;
     }
+#if MUSY_VERSION >= MUSY_VERSION_CHECK(2, 0, 3)
+    vs.streamBuffer[sb].info.data.start.extraData = hwGetSampleExtraData(hwVoice);
+#else
     vs.streamBuffer[sb].info.data.start.extraData = hwGetSampleExtraData(voice);
 #endif
+#endif
+#if MUSY_VERSION >= MUSY_VERSION_CHECK(2, 0, 3)
+    vs.streamBuffer[sb].smpType = hwGetSampleType(hwVoice);
+#else
     vs.streamBuffer[sb].smpType = hwGetSampleType(voice);
+#endif
     vs.streamBuffer[sb].voice = voice;
     if (vs.callback != NULL && (MUSY_VERSION <= MUSY_VERSION_CHECK(2, 0, 1)
                                     ? TRUE
@@ -104,12 +128,20 @@ u32 vsSampleStartNotify(
 #endif
       return (vs.streamBuffer[sb].info.instID << 8) | voice;
     }
+#if MUSY_VERSION >= MUSY_VERSION_CHECK(2, 0, 3)
+    hwSetVirtualSampleLoopBuffer(hwVoice, 0, 0);
+#else
     hwSetVirtualSampleLoopBuffer(voice, 0, 0);
+#endif
 #if MUSY_VERSION >= MUSY_VERSION_CHECK(2, 0, 2)
     vsFreeBuffer(sb);
 #endif
   } else {
+#if MUSY_VERSION >= MUSY_VERSION_CHECK(2, 0, 3)
+    hwSetVirtualSampleLoopBuffer(hwVoice, 0, 0);
+#else
     hwSetVirtualSampleLoopBuffer(voice, 0, 0);
+#endif
   }
 
   return 0xFFFFFFFF;

--- a/src/musyx/runtime/synthmacros.c
+++ b/src/musyx/runtime/synthmacros.c
@@ -1631,7 +1631,7 @@ static void macHandleActive(SYNTH_VOICE* svoice) {
     case 0x5a:
       mcmdSRCModeSelect(svoice, &cstep);
       break;
-#if MUSY_VERSION == MUSY_VERSION_CHECK(2, 0, 1)
+#if MUSY_VERSION == MUSY_VERSION_CHECK(2, 0, 1) || MUSY_VERSION == MUSY_VERSION_CHECK(2, 0, 3)
     case 0x5e:
       mcmdFilterSwitchSelect(svoice, &cstep);
       break;

--- a/src/musyx/runtime/synthvoice.c
+++ b/src/musyx/runtime/synthvoice.c
@@ -693,7 +693,14 @@ void synthInitAllocationAids() {
 u32 voiceBlock(u8 prio) {
   u32 voice;
 
+#if MUSY_VERSION >= MUSY_VERSION_CHECK(2, 0, 3)
+  voice = voiceAllocateFind(prio, 0xFF, 0xFFFF, 1);
+  voiceAllocateDo(voice, 1);
+
+  if (voice != 0xFFFFFFFF) {
+#else    
   if ((voice = voiceAllocate(prio, 0xFF, 0xFFFF, 1)) != 0xFFFFFFFF) {
+#endif
     synthVoice[voice].block = 1;
     synthVoice[voice].fxFlag = 1;
 


### PR DESCRIPTION
## Summary

Super Mario Strikers (GameCube, `G4QE01`) ships **MusyX 2.0.3**. This PR adds the
2.0.3-specific runtime behaviour, fully **version-gated** behind `MUSY_VERSION` so
existing consumers (`MUSY_VERSION <= 2.0.2`) are completely unaffected.

7 files, +196/-8, every change behind a `#if MUSY_VERSION ...` guard:

`synthmacros.c` : 2.0.1-style `0x5e`/`0x5f` filter-command dispatch 
`synthvoice.c` : `voiceBlock()` split into `voiceAllocateFind` / `voiceAllocateDo` 
`hw_dspctrl.c` : `compressorTable` `ALIGN(32)`, `AddDpop` inlined, unused dsp mixer-aux / studio helpers dropped
`stream.c` : stream rework (`streamKill` voice scan, inlined `GeneratePublicID`, tentative `streamCallCnt`/`streamCallDelay`); pre-2.0.3 stream APIs dropped 
`s_data.c` : 2.0.3 sequence-play via `_seqPlaySong`; `gsRoot`/`gsCurrent`/`gsNextID` order 
`synth_vsamples.c` : `vsSampleStartNotify` `hwVoice` handling 
`hw_dolphin.c` : 2.0.3 file-scope declaration layout + `salWaitForDSPThreadQueue` 

## Verification

- I tried to validate the C preprocessor output for all versions for `MUSY_VERSION` 1.5.3 / 1.5.4 / 2.0.0 / 2.0.1 / 2.0.2 (each gate evaluates to the original code for those versions).
- 2.0.3 correctness — the 2.0.3 path reproduces the retail SMS object code: the decompilation links to a byte-identical `main.dol` (SHA1 OK) with every MusyX translation unit at 100%.

## Note

While adding 2.0.3 support I noticed `hw_dolphin.c` uses `salWaitForDSPThreadQueue`
(`dspDoneCallback`, `OSInitThreadQueue`, `OSSleepThread`) but never declares it at file
scope for `>= 2.0.2`. To stay byte-neutral I added the declaration only inside the 2.0.3
arm; if that's a latent bug for 2.0.2, I'm happy to move it to `>= 2.0.2` separately.

Happy to adjust the gating style, squash, or split however you prefer.
