### PR TITLE
fix incompatible declarations: prefer u32

### DIFF
--- a/include/musyx/hardware.h
+++ b/include/musyx/hardware.h
@@ -166,8 +166,8 @@ void aramSyncTransferQueue();
   void aramInit(unsigned long length);
   void aramExit();
   size_t aramGetStreamBufferAddress(u8 id, size_t* len);
-  void aramUploadData(void* mram, unsigned long aram, unsigned long len, unsigned long highPrio, void (*callback)(size_t),
-                      unsigned long user);
+  void aramUploadData(void* mram, u32 aram, u32 len, u32 highPrio, void (*callback)(size_t),
+                      u32 user);
   void aramFreeStreamBuffer(u8 id);
   void* aramStoreData(void* src, unsigned long len
   #if MUSY_VERSION >= MUSY_VERSION_CHECK(2, 0, 1)

--- a/src/musyx/runtime/hw_aramdma.c
+++ b/src/musyx/runtime/hw_aramdma.c
@@ -81,8 +81,8 @@ static void aramQueueCallback(unsigned long ptr) {
   --aramQueue->valid;
 }
 
-void aramUploadData(void* mram, unsigned long aram, unsigned long len, unsigned long highPrio,
-                    void (*callback)(size_t), unsigned long user) {
+void aramUploadData(void* mram, u32 aram, u32 len, u32 highPrio, void (*callback)(size_t),
+                    u32 user) {
   ARAMTransferQueue* aramQueue; // r31
   int old;                      // r30
 
@@ -452,8 +452,8 @@ static void aramQueueInit() {}
 
 static void aramQueueCallback(unsigned long ptr) {}
 
-void aramUploadData(void* mram, unsigned long aram, unsigned long len, unsigned long highPrio,
-                    void (*callback)(unsigned long), unsigned long user) {}
+void aramUploadData(void* mram, u32 aram, u32 len, u32 highPrio, void (*callback)(size_t),
+                    u32 user) {}
 
 void aramSyncTransferQueue() {}
 


### PR DESCRIPTION
This fixes aramUploadData to consistently use u32 instead of unsigned long for pc targets and u32 for dolphin targets