### PR TITLE
Gate the remaining Dolphin-only code behind MUSY_TARGET_DOLPHIN

### DIFF
--- a/include/musyx/txwin.h
+++ b/include/musyx/txwin.h
@@ -1,6 +1,12 @@
 #ifndef _MUSYX_TXWIN
 #define _MUSYX_TXWIN
 
+#include "musyx/platform.h"
+
+/* A debug text window drawn with GX. Dolphin-only: there is no PC counterpart,
+ * and nothing outside the Dolphin backend references it. */
+#if MUSY_TARGET == MUSY_TARGET_DOLPHIN
+
 #include <dolphin/types.h>
 
 #ifdef __cplusplus
@@ -46,4 +52,5 @@ sWIN* winOpenWindow(s32 x1, s32 y1, s32 x2, s32 y2, char* caption, void* func, u
 #ifdef __cpluplus
 }
 #endif // __cpluplus
+#endif // MUSY_TARGET == MUSY_TARGET_DOLPHIN
 #endif // _MUSYX_TXWIN

--- a/include/musyx/txwin.h
+++ b/include/musyx/txwin.h
@@ -49,8 +49,8 @@ sWIN* winOpenWindow(s32 x1, s32 y1, s32 x2, s32 y2, char* caption, void* func, u
 
 // WXOpenWindow();
 
-#ifdef __cpluplus
+#ifdef __cplusplus
 }
-#endif // __cpluplus
+#endif // __cplusplus
 #endif // MUSY_TARGET == MUSY_TARGET_DOLPHIN
 #endif // _MUSYX_TXWIN

--- a/src/musyx/runtime/profile.c
+++ b/src/musyx/runtime/profile.c
@@ -1,5 +1,5 @@
 #include "musyx/platform.h"
-#if MUSYX_PLATFORM == MUSYX_DOLPHIN
+#if MUSY_TARGET == MUSY_TARGET_DOLPHIN
 #include "dolphin/PPCArch.h"
 #include "musyx/musyx.h"
 

--- a/src/musyx/txwin/txwin.c
+++ b/src/musyx/txwin/txwin.c
@@ -1,3 +1,7 @@
+#include "musyx/platform.h"
+
+#if MUSY_TARGET == MUSY_TARGET_DOLPHIN
+
 #include "musyx/txwin.h"
 #include "dolphin/gx.h"
 #include "dolphin/os.h"
@@ -230,3 +234,5 @@ static void __win_log_refresh(struct STRUCT_WIN* handle /* r31 */) {
     DEMOPrintf(x, y, 0, "%s", handle->buffer[n]);
   }
 }
+
+#endif // MUSY_TARGET == MUSY_TARGET_DOLPHIN


### PR DESCRIPTION
Small follow-up from your review on #9 — the self-contained part of the "gate Dolphin-specific code" point, split out so it can be judged on its own. No dependency on the PC backend work.

`profile.c` was guarded with `MUSYX_PLATFORM == MUSYX_DOLPHIN`. Neither macro is defined anywhere in the tree, so in `#if` both expand to `0` and the guard reads `0 == 0` — always true. It only avoids breaking a non-Dolphin build because `profile.c` isn't in the source list, so the guard looks protective while doing nothing; adding the file to a build would pull in `dolphin/PPCArch.h` regardless of target.

`txwin.c` / `txwin.h` had no guard at all. The text window is drawn with GX and has no counterpart on other targets, so both are now Dolphin-only in the source rather than by omission from the build.

With these three, every `<dolphin/...>` include in the tree sits behind `MUSY_TARGET_DOLPHIN`, which makes the property checkable:

```
grep -rn '#include *[<"]dolphin' src include
```

The second commit is a drive-by in a file already being touched, happy to drop it if you'd rather keep this focused: `txwin.h` opens `extern "C"` under `__cplusplus` but closed it under `__cpluplus`, which is never defined — so a C++ translation unit including the header opened the block and never closed it. Harmless today since `txwin.c` is the only includer and is plain C.

No functional change on Dolphin: all three files were compiled there before and still are.

Thanks again for taking the time to review #9 after I'd closed it — the ARAM and dspctrl points need more thought and I'll come back on those separately. You were also right about the byte order rationale; that fix lives in a file this PR doesn't touch, so it'll come with the backend work.